### PR TITLE
Arborx update

### DIFF
--- a/codes/arborx.bash
+++ b/codes/arborx.bash
@@ -24,7 +24,7 @@ exawind_cmake_base ()
     local cmake_cmd=(
         cmake
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-RELEASE}
-        -DCMAKE_PREFIX_PATH=${TRILINOS_ROOT_DIR}
+        -DKokkos_ROOT=${TRILINOS_ROOT_DIR}
         -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON
         -DARBORX_ENABLE_BENCHMARKS=OFF
         -DARBORX_ENABLE_TESTS=OFF

--- a/codes/tioga-utils.bash
+++ b/codes/tioga-utils.bash
@@ -8,6 +8,9 @@ exawind_proj_env ()
     if [ "${ENABLE_NALU_WIND:-OFF}" = "ON" ] ; then
         exawind_load_deps nalu-wind
     fi
+    if [ "${ENABLE_ARBORX:-OFF}" = "ON" ] ; then
+        exawind_load_deps arborx
+    fi
 }
 
 exawind_cmake_base ()
@@ -17,6 +20,12 @@ exawind_cmake_base ()
     if [ -n "$TIOGA_UTILS_INSTALL_PREFIX" ] ; then
         install_dir="-DCMAKE_INSTALL_PREFIX=$TIOGA_UTILS_INSTALL_PREFIX"
     fi
+
+    cmake_prefix_path=""
+    if [ "${ENABLE_ARBORX}" == "ON" ]; then
+        cmake_prefix_path="-DCMAKE_PREFIX_PATH=\"$ARBORX_ROOT_DIR\""
+    fi
+
 
     local compiler_flags=$(exawind_get_compiler_flags)
 
@@ -37,6 +46,7 @@ exawind_cmake_base ()
         -DENABLE_NALU_WIND:BOOL=${ENABLE_NALU_WIND:-OFF}
         -DNALU_DIR:PATH=${NALU_WIND_ROOT_DIR}
         -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON
+        ${cmake_prefix_path}
         ${compiler_flags}
         ${install_dir}
         ${extra_args}

--- a/codes/tioga.bash
+++ b/codes/tioga.bash
@@ -37,6 +37,7 @@ exawind_cmake_base ()
     local cmake_cmd=(
         cmake
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-RELEASE}
+        -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS:-OFF}
         -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON
         -DTIOGA_ENABLE_CUDA=${ENABLE_CUDA:-OFF}
         -DTIOGA_CUDA_SM=${EXAWIND_CUDA_SM:-70}

--- a/codes/tioga.bash
+++ b/codes/tioga.bash
@@ -34,6 +34,13 @@ exawind_cmake_base ()
         install_dir="-DCMAKE_INSTALL_PREFIX=$TIOGA_INSTALL_PREFIX"
     fi
 
+    local compiler_flags=$(exawind_get_compiler_flags)
+
+    cmake_prefix_path=""
+    if [ "${ENABLE_ARBORX}" == "ON" ]; then
+        cmake_prefix_path="-DCMAKE_PREFIX_PATH=\"$ARBORX_ROOT_DIR\""
+    fi
+
     local cmake_cmd=(
         cmake
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-RELEASE}
@@ -42,11 +49,12 @@ exawind_cmake_base ()
         -DTIOGA_ENABLE_CUDA=${ENABLE_CUDA:-OFF}
         -DTIOGA_CUDA_SM=${EXAWIND_CUDA_SM:-70}
         -DTIOGA_ENABLE_ARBORX:BOOL=${ENABLE_ARBORX:-OFF}
-        -DCMAKE_PREFIX_PATH="$ARBORX_ROOT_DIR\\;$TRILINOS_ROOT_DIR"
+        ${cmake_prefix_path}
         -DTIOGA_HAS_NODEGID=${TIOGA_HAS_NODEGID:-OFF}
         -DTIOGA_ENABLE_TIMERS=${TIOGA_ENABLE_TIMERS:-OFF}
         -DTIOGA_OUTPUT_STATS=${TIOGA_OUTPUT_STATS:-OFF}
         ${install_dir}
+        ${compiler_flags}
         ${extra_args}
         ${TIOGA_SOURCE_DIR:-..}
     )

--- a/codes/trilinos.bash
+++ b/codes/trilinos.bash
@@ -94,7 +94,6 @@ exawind_cmake_base ()
             -DTpetra_INST_CUDA:BOOL=${enable_cuda}
             -DKokkos_ENABLE_CUDA_LAMBDA:BOOL=${enable_cuda}
             -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE:BOOL=${enable_cuda}
-            -DKokkos_ENABLE_DEPRECATED_CODE:BOOL=OFF
             -DTpetra_INST_SERIAL:BOOL=ON
             -DTrilinos_ENABLE_CXX11:BOOL=ON
             -DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON


### PR DESCRIPTION
This is in a pretty rough shape, but looking for a feedback.

Main issues:
- I have only tested it with Trilinos Serial so far
  I tested it with CUDA back in Jan, but not recently
- Depending on ArborX means we need to load Trilinos too
  This is mainly because enabling CUDA means we need to fetch `nvcc_wrapper`
- I hope to have updated `arborx` in spack soon
  However, `spack`'s trilinos does not support cuda right now, and unclear when it will, so this may not be helpful
- This is untested with `nalu-wind`

Overall, I'm only about 50% sure what works and what does not, and need help figuring it out.