### PR TITLE
Changing default compiler to gcc 9.3, cuda 11.0.3. Also, I've made it…

### DIFF
--- a/envs/ornl-summit.bash
+++ b/envs/ornl-summit.bash
@@ -55,7 +55,7 @@ exawind_env_gcc ()
     #exawind_spack_env gcc
     exawind_load_deps mpi gcc cuda cmake netlib-lapack hdf5
 
-    export EXAWIND_GCC_VERSION=${EXAWIND_GCC_VERSION:-10.2.0}
+    export EXAWIND_GCC_VERSION=${EXAWIND_GCC_VERSION:-9.3.0}
 
     export CXX=$(which g++)
     export CC=$(which gcc)

--- a/etc/bootstrap/ornl-summit.bash
+++ b/etc/bootstrap/ornl-summit.bash
@@ -6,5 +6,5 @@ fi
 
 if [ "${EXAWIND_COMPILER}" = "gcc" ] ; then
    module unload xl
-   module load gcc/10.2.0
+   module load gcc/9.3.0
 fi

--- a/etc/spack/ornl-summit/compilers.yaml
+++ b/etc/spack/ornl-summit/compilers.yaml
@@ -59,7 +59,7 @@ compilers:
     operating_system: rhel8
     target: ppc64le
     modules:
-    - gcc/9.3.0
+    - gcc/9.1.0
     environment: {}
     extra_rpaths:
     - /sw/summit/gcc/9.1.0-alpha+20190716/lib

--- a/etc/spack/ornl-summit/packages.yaml
+++ b/etc/spack/ornl-summit/packages.yaml
@@ -1,20 +1,19 @@
 packages:
   all:
     compiler:
-      - gcc@10.2.0
+      - gcc@9.3.0
     providers:
       mpi:
         - spectrum-mpi
   spectrum-mpi:
     buildable: false
     externals:
-
-      - spec: "spectrum-mpi@10.4%gcc@10.2.0"
+      - spec: "spectrum-mpi@10.4%gcc@9.3.0"
         modules:
-          - gcc/10.2.0
+          - gcc/9.3.0
           - spectrum-mpi/10.4.0.3-20210112
   cuda:
-    version: [11.3.1]
+    version: [11.0.3]
     buildable: false
     externals:
       - spec: "cuda@10.1.168"
@@ -41,6 +40,27 @@ packages:
       - spec: "cuda@11.4.0"
         modules:
           - cuda/11.4.0
+  hdf5:
+    version: [1.10.7]
+    buildable: false
+    externals:
+      - spec: "hdf5@1.10.7%gcc"
+        modules:
+          - hdf5/1.10.7
+  netcdf-c:
+    version: [4.8.1]
+    buildable: false
+    externals:
+      - spec: "netcdf-c@4.8.1%gcc"
+        modules:
+          - netcdf-c/4.8.1
+  parallel-netcdf:
+    version: [1.12.2]
+    buildable: false
+    externals:
+      - spec: "parallel-netcdf@1.12.2%gcc"
+        modules:
+          - parallel-netcdf/1.12.2
   cmake:
     version: [3.20.2]
     buildable: false
@@ -61,8 +81,9 @@ packages:
   bzip2:
     version: [1.0.6]
     buildable: false
-    paths:
-      bzip2@1.0.6: /usr/
+    externals:
+      - spec: "bzip2@1.0.6"
+        prefix: /usr/
   libxml2:
     version: [2.9.10]
     buildable: false
@@ -73,8 +94,9 @@ packages:
   m4:
     version: [1.4.18]
     buildable: false
-    paths:
-      m4@1.4.18: /usr/
+    externals:
+      - spec: "m4@1.4.18"
+        prefix: /usr/
   perl:
     version: [5.26.2]
     buildable: false
@@ -106,8 +128,9 @@ packages:
   pkgconf:
     version: [1.4.2]
     buildable: false
-    paths:
-      pkgconf@1.4.2: /usr/
+    externals:
+      - spec: "pkgconf@1.4.2"
+        prefix: /usr/
   python:
     version: [3.7.0]
     buildable: false

--- a/etc/spack/ornl-summit/spack-matrix.yaml
+++ b/etc/spack/ornl-summit/spack-matrix.yaml
@@ -4,9 +4,9 @@ spack:
     all:
       variants: +mpi+pic build_type=Release
   definitions:
-    - compilers: [ '%gcc@10.2.0' ]
+    - compilers: [ '%gcc@9.3.0' ]
   specs:
-    - cuda@11.3.1
+    - cuda@11.0.3
     - matrix:
         - [ cmake, ninja-fortran, mpi, m4, zlib, bzip2, libxml2, boost, superlu,
             netlib-lapack, hdf5, netcdf-c, parmetis, yaml-cpp, openfast ]
@@ -14,15 +14,15 @@ spack:
     - matrix:
         - [ trilinos ]
         - [ '~cuda~wrapper',
-            '+cuda+cuda_rdc+wrapper~shared cuda_arch=70 ^cuda@11.3.1' ]
+            '+cuda+cuda_rdc+wrapper~shared cuda_arch=70 ^cuda@11.0.3' ]
         - [ $compilers ]
     - matrix:
         - [ hypre ]
-        - [ '~cuda+int64' , '+cuda~int64 cuda_arch=70 ^cuda@11.3.1' ]
+        - [ '~cuda+int64' , '+cuda~int64 cuda_arch=70 ^cuda@11.0.3' ]
         - [ $compilers ]
     - matrix:
         - [ tioga~nodegid, amr-wind, nalu-wind ]
-        - [ '~cuda', '+cuda~shared cuda_arch=70 ^cuda@11.3.1']
+        - [ '~cuda', '+cuda~shared cuda_arch=70 ^cuda@11.0.3']
         - [ $compilers ]
     - matrix:
         - [ nalu-wind-utils, tioga-utils ]


### PR DESCRIPTION
… so that certain modules aren't buildable on summit (hdf5, netcdf, parallel-netcdf). We use the installed modules.